### PR TITLE
Feature append image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-error.log*
 /live/
 .env
 .env.local
+.build

--- a/graphcool/src/tweet.graphql
+++ b/graphcool/src/tweet.graphql
@@ -1,5 +1,6 @@
 type TweetPayload {
   result: String!
+  image: String
 }
 
 extend type Query {

--- a/graphcool/src/tweet.js
+++ b/graphcool/src/tweet.js
@@ -1,14 +1,12 @@
 const Twit = require('./twit')
 
-const getRandom = max => Math.floor(Math.random() * max)
-
 export default async () => {
-  const tweets = await Twit()
-  const result = tweets.data[getRandom(tweets.data.length)].text
+  const result = await Twit()
 
   return {
     data: {
-      result
+      result: result.text,
+      image: result.text
     }
   }
 }

--- a/graphcool/src/twit.js
+++ b/graphcool/src/twit.js
@@ -9,21 +9,60 @@ const t = new Twit({
 })
 
 /**
- * Obtiene tweets
- * @param {number} count - maximo de tweets a extraer
- * @return {Promise}
+ * Obtiene imagen incrustada desde un tweet.
+ *
+ * @param {Object} data - Objecto con data de un tweet.
+ * @return {Promise<string>} URL de una imagen.
  */
-const getTweet = (count = 200) =>
-  new Promise(resolve => {
-    t
-      .get('statuses/user_timeline', {
-        screen_name: 'ideasdelavin',
-        count,
-        exclude_replies: true,
-        include_rts: false,
-        trim_user: true
-      })
-      .then(result => resolve(result))
-  })
+const getImageFromEntities = async data => {
+  if (data.entities.media && data.entities.media.length > 0) {
+    return data.entities.media[0].media_url_https
+  } else if (data.entities.urls && data.entities.urls.length > 0) {
+    const id = data.entities.urls[0].expanded_url.replace(/https?:\/\/twitter.com\/\w+\/status\/(\w+)/, '$1')
+    const urlData = await t.get(`statuses/show/${id}`)
+    return getImageFromEntities(urlData)
+  } else {
+    return null
+  }
+}
+
+/**
+ * Determina si un tweet posee una imagen incrustada.
+ *
+ * @param {string} text - Texto de un tweet.
+ * @return {boolean}
+ */
+const hasImage = text => /https:\/\/t.co\/\w+/.test(text)
+
+/**
+ * Obtiene un numero random dado un numero máximo.
+ *
+ * @param {number} max - Texto de un tweet.
+ * @return {number}
+ */
+const getRandom = max => Math.floor(Math.random() * max)
+
+/**
+ * Obtiene tweets
+ * @param {number} [count=20] - maximo de tweets a extraer
+ * @return {Promise<Object>}
+ */
+const getTweet = async (count = 200) => {
+  const tweets = await t
+    .get('statuses/user_timeline', {
+      screen_name: 'ideasdelavin',
+      count,
+      exclude_replies: true,
+      include_rts: false,
+      trim_user: true,
+      include_entities: true
+    })
+  const result = tweets.data[getRandom(tweets.data.length)]
+  if (hasImage(result.text)) {
+    const image = await getImageFromEntities(result)
+    result.image = image
+  }
+  return result
+}
 
 module.exports = getTweet


### PR DESCRIPTION
Agrego `image` (`String`) a `TweetPayload` en caso de que tenga una imagen incrustada.

Ejemplo de uso:

```gql
query {
  tweet {
    result
    image
  }
}
```

```json
{
  "result": "Dildos de chocolate con forma de viejo pascuero https://t.co/WAxyi75KtD",
  "image": "https://pbs.twimg.com/media/DrUJTuPWwAAEn7C.jpg"
}
```